### PR TITLE
Fix imports and source directory settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ elm-package install
 ### Building
 To compile the source code and run a live server run the following command:
 ```bash
-elm-live src/Main.elm src/Zipper.elm src/Editor.elm src/Core/Proof.elm src/Core/Matcher.elm src/History.elm src/Exporting/Json/Decode.elm src/Exporting/Json/Encode.elm src/Exporting/Ports.elm src/Core/Types.elm src/Core/Validator.elm --open --pushstate --output=elm.js
+elm-live src/Main.elm --open --pushstate --output=elm.js
 ```

--- a/elm-package.json
+++ b/elm-package.json
@@ -3,7 +3,9 @@
     "summary": "Like GitHub, but for Elm stuff.",
     "repository": "https://github.com/ZoltanOnody/proof-assistant.git",
     "license": "BSD-3-Clause",
-    "source-directories": ["."],
+    "source-directories": [
+	"src"
+    ],
     "exposed-modules": [],
     "dependencies": {
         "elm-lang/core": "5.0.0 <= v < 6.0.0",

--- a/src/Core/Proof.elm
+++ b/src/Core/Proof.elm
@@ -1,4 +1,4 @@
-module Proof
+module Core.Proof
     exposing
         ( Where(..)
         , addCases
@@ -20,8 +20,8 @@ import Dict
 import Formula
 import List.Extra
 import Parser
-import Types exposing (..)
-import Validator
+import Core.Types exposing (..)
+import Core.Validator as Validator
 
 
 type Where

--- a/src/Core/Types.elm
+++ b/src/Core/Types.elm
@@ -1,4 +1,10 @@
-module Types exposing (Explanation(..), FormulaStep, GUI, Justification(..), Proof(..))
+module Core.Types
+    exposing
+    ( Explanation(..)
+    , FormulaStep
+    , GUI
+    , Justification(..)
+    , Proof(..))
 
 import Formula
 import Parser

--- a/src/Core/Validator.elm
+++ b/src/Core/Validator.elm
@@ -1,10 +1,10 @@
-module Validator exposing (..)
+module Core.Validator exposing (..)
 
 import Core.Matcher as Matcher
 import Formula
 import Maybe.Extra as MaybeExtra
 import Set
-import Types exposing (..)
+import Core.Types exposing (..)
 
 
 type alias Validator =

--- a/src/Editor.elm
+++ b/src/Editor.elm
@@ -29,8 +29,8 @@ import Http
 import Json.Decode
 import Json.Encode
 import Parser exposing (..)
-import Proof
-import Types exposing (..)
+import Core.Proof as Proof
+import Core.Types exposing (..)
 import Zipper
 
 

--- a/src/Exporting/Json/Decode.elm
+++ b/src/Exporting/Json/Decode.elm
@@ -1,8 +1,8 @@
 module Exporting.Json.Decode exposing (decode)
 
 import Json.Decode exposing (..)
-import Proof
-import Types exposing (..)
+import Core.Proof as Proof
+import Core.Types exposing (..)
 
 
 createFormulaStepForDecoder text =

--- a/src/Exporting/Json/Encode.elm
+++ b/src/Exporting/Json/Encode.elm
@@ -2,8 +2,8 @@ module Exporting.Json.Encode exposing (encode, jsonDataUri)
 
 import Http
 import Json.Encode exposing (..)
-import Proof
-import Types exposing (..)
+import Core.Proof as Proof
+import Core.Types exposing (..)
 
 
 jsonDataUri : String -> String

--- a/src/Zipper.elm
+++ b/src/Zipper.elm
@@ -29,9 +29,9 @@ module Zipper
         )
 
 import Formula
-import Proof
-import Types exposing (..)
-import Validator
+import Core.Proof as Proof
+import Core.Types as Types exposing (..)
+import Core.Validator as Validator
 
 
 type alias Zipper =


### PR DESCRIPTION
Fix qualified names in imports and elm-package source directory settings
so that `elm-make` figures out `Main`'s dependencies automatically.